### PR TITLE
Escape braces in HTML template to prevent formatting errors

### DIFF
--- a/rolomemo.py
+++ b/rolomemo.py
@@ -245,22 +245,22 @@ HTML_TEMPLATE = """<!DOCTYPE html>
     <script src="{babel}"></script>
     <link rel="stylesheet" href="{tailwind}">
     <style>
-        .line-clamp-3 {
+        .line-clamp-3 {{
             display: -webkit-box;
             -webkit-line-clamp: 3;
             -webkit-box-orient: vertical;
             overflow: hidden;
-        }
-        
+        }}
+
         /* Personalizzazioni tema */
-        :root {
+        :root {{
             --color-cream: #fff7ea;
             --color-avocado: #7a8f3c;
             --color-burnt: #c1542a;
             --color-ink: #1d1d1f;
             --color-smoke: #3b3b40;
             --color-mustard: #d6a516;
-        }
+        }}
     </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- Escape CSS blocks in `HTML_TEMPLATE` by doubling curly braces so `str.format` doesn't misinterpret them

## Testing
- `python -m py_compile rolomemo.py`
- `python - <<'PY'
import rolomemo
print('html length', len(rolomemo.create_html()))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68bd785967888326bc644a415a4f2318